### PR TITLE
fix(Dribbblish): adding more padding on top

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -1,3 +1,9 @@
+/* adding more padding on top */
+.Root {
+  padding-top: 30px;
+}
+/*done */
+
 :root {
     --bar-height: 70px;
     --bar-cover-art-size: 40px;

--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -1,8 +1,6 @@
-/* adding more padding on top */
 .Root {
   padding-top: 30px;
 }
-/*done */
 
 :root {
     --bar-height: 70px;


### PR DESCRIPTION
adding more padding on top so 3 dot and close and minimize buttons will not any longer seems buggy