### PR TITLE
fix(Onepunch): disable show prog-tooltip class to improve now playing UI

### DIFF
--- a/Onepunch/user.css
+++ b/Onepunch/user.css
@@ -405,3 +405,7 @@ input {
   border-radius: 10px !important;
   background-color: var(--spice-sec-player) !important;
 }
+
+.prog-tooltip {
+  display: none;
+}


### PR DESCRIPTION
On newest version of Spotify the `prog-tooltip` class appear on now playing container, so disabling this class solves problem

Before:
![before](https://user-images.githubusercontent.com/44818681/180735367-7c1b0b88-55c8-4188-9b9c-e0a8abe1b995.png)
After:
![after](https://user-images.githubusercontent.com/44818681/180735424-3adfdae2-a906-4d39-ba85-f995660906af.png)

