### PR TITLE
fix(dribbblish): fix sidebar playlist padding

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -491,7 +491,7 @@ html.sidebar-hide-text .main-rootlist-statusIcons {
     border-radius: 4px;
     display: flex;
     height: 56px;
-    padding: 0 20px;
+    padding: 0 12px;
 }
 
 img.playlist-picture {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/55749227/186206858-63fd83a3-bdf9-414a-a1a6-3dab080621fe.png)

After:
![image](https://user-images.githubusercontent.com/55749227/186206891-e66968bc-7575-4d42-8117-114ee0b48ca3.png)
