### PR TITLE
[Dribbblish] CSS grid fixes

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -712,14 +712,23 @@ li.GlueDropTarget {
 }
 
 /** Grid */
+
 .Root__top-container {
-    grid-template-areas:
-        "nav-bar main-view buddy-feed"
-        "nav-bar now-playing-bar buddy-feed";
     padding: var(--main-gap) 0;
 }
 
+.spotify__container--is-desktop.buddyfeed-visible .Root__top-container {
+    grid-template-areas:
+        "top-bar top-bar top-bar"
+        "nav-bar main-view buddy-feed"
+        "nav-bar now-playing-bar buddy-feed";
+}
+
 html:not(.buddyfeed-visible) .Root__top-container {
+    grid-template-areas:
+        "top-bar top-bar"
+        "nav-bar main-view"
+        "nav-bar now-playing-bar";
     padding-right: var(--main-gap);
 }
 


### PR DESCRIPTION
Edited the grid placement of some elements to fix two UI bugs:
- The playing bar element was incorrectly spanning the whole window, changed the grid template so that it only spans the main view
- The drop shadow on the main view was way too long, and clipping outside the window. I changed the element's placement so I could place it on the grid so the height is properly calculated