### PR TITLE
fix(dribbblish): bottom bar and box shadow

### DIFF
--- a/Dribbblish/dribbblish.js
+++ b/Dribbblish/dribbblish.js
@@ -93,10 +93,10 @@ waitForElement([
         .observe(listElem, {childList: true});
 });
 
-waitForElement([".Root__main-view"], ([mainView]) => {
+waitForElement([".Root__top-container"], ([topContainer]) => {
     const shadow = document.createElement("div");
     shadow.id = "dribbblish-back-shadow";
-    mainView.prepend(shadow);
+    topContainer.prepend(shadow);
 });
 
 waitForElement([".main-rootlist-rootlistPlaylistsScrollNode"], (queries) => {
@@ -130,8 +130,6 @@ waitForElement([".Root__main-view .os-resize-observer-host"], ([resizeHost]) => 
     function updateVariable([ event ]) {
         document.documentElement.style.setProperty(
             "--main-view-width", event.contentRect.width + "px");
-        document.documentElement.style.setProperty(
-            "--main-view-height", event.contentRect.height + "px");
         if (event.contentRect.width < 700) {
             document.documentElement.classList.add("minimal-player");
         } else {

--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -712,14 +712,23 @@ li.GlueDropTarget {
 }
 
 /** Grid */
+
 .Root__top-container {
-    grid-template-areas:
-        "nav-bar main-view buddy-feed"
-        "nav-bar now-playing-bar buddy-feed";
     padding: var(--main-gap) 0;
 }
 
+.spotify__container--is-desktop.buddyfeed-visible .Root__top-container {
+    grid-template-areas:
+        "top-bar top-bar top-bar"
+        "nav-bar main-view buddy-feed"
+        "nav-bar now-playing-bar buddy-feed";
+}
+
 html:not(.buddyfeed-visible) .Root__top-container {
+    grid-template-areas:
+        "top-bar top-bar"
+        "nav-bar main-view"
+        "nav-bar now-playing-bar";
     padding-right: var(--main-gap);
 }
 

--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -593,12 +593,10 @@ li.GlueDropTarget {
     padding-bottom: 56px;
 }
 #dribbblish-back-shadow {
-    position: fixed;
-    width: var(--main-view-width);
-    height: calc(var(--main-view-height) + var(--bar-height));
+    z-index: 2;
+    grid-area: main-view / main-view / now-playing-bar / main-view;
     box-shadow: 0 0 10px 3px #0000003b;
     border-radius: var(--main-corner-radius);
-    z-index: 2;
     pointer-events: none;
 }
 


### PR DESCRIPTION
Edited the grid layout a little bit, to fix two different UI bugs:
- When the friend activity panel is showing, the bottom playback bar is way too long:
![image](https://user-images.githubusercontent.com/13788817/190881733-9adb9c21-85e9-4055-88e3-af181f32a7b1.png)
after the fix:
![image](https://user-images.githubusercontent.com/13788817/190881798-15190704-05ac-419f-b676-75b08e9fdff3.png)
- Second bug has to do with the shadow around the main element, as sometimes it is incorrectly drawn and it extends all the way to the bottom:
![image](https://user-images.githubusercontent.com/13788817/190881851-ffafdd15-e600-4066-ba5a-970c826664c9.png)
after the fix:
![image](https://user-images.githubusercontent.com/13788817/190881917-bc46dd96-a7e7-4fc1-9d12-b99a9d8e7126.png)

I removed the `--main-view-height` CSS variable as it's not really useful, considering it doesn't actually reflect the computed height since there is some overlap between it and the bottom bar. The element that actually renders the drop shadow is now on the CSS grid with the other elements so its size is automatically calculated. Other than that, I don't think any of the other changes are particularly invasive.