### PR TITLE
fix(Dribbblish): invisible playlist play buttons

### DIFF
--- a/Dribbblish/dribbblish.js
+++ b/Dribbblish/dribbblish.js
@@ -41,6 +41,21 @@ waitForElement([".main-rootlist-wrapper"], () => {
     mainRootlist.style.height = `${playListItems.length * 56}px`;
 });
 
+// Change colour of playlist play icons in certain color schemes to avoid invisibility
+waitForElement([".main-playButton-PlayButton"], () => {
+    const buttonStyle = getComputedStyle(document.querySelector('.fpCtYO'));
+    if(buttonStyle.color === buttonStyle.backgroundColor) {
+        const style = document.createElement('style');
+        style.innerText = `.fpCtYO {
+            color: var(--spice-text);
+        }
+        .gHYQaG {
+            color: var(--spice-text);
+        }`;
+        document.head.appendChild(style);
+    }
+});
+
 waitForElement([
     `ul[tabindex="0"]`,
     `ul[tabindex="0"] .GlueDropTarget--playlists.GlueDropTarget--folders`


### PR DESCRIPTION
Added some JS to change the color of the playlist play button icons if the background color and color are the same which happens in the case of certain color schemes like base, dark and purple. Resolves #852.

Before:

Purple scheme
![image](https://user-images.githubusercontent.com/84299080/198303382-141e7861-663e-4ad0-9b90-7246f12f6089.png)
![image](https://user-images.githubusercontent.com/84299080/198304399-f1189dc4-df08-4b52-bae0-c23018f58e78.png)


After:

Purple scheme
![image](https://user-images.githubusercontent.com/84299080/198304836-e0225502-469a-4311-88bf-537ab03d1b86.png)
![image](https://user-images.githubusercontent.com/84299080/198304935-3592a81b-c0b8-40b1-b9c6-cf780c06df12.png)

Schemes not affected by the bug have no change in button colors.

I fixed the bug by changing the `color` properties of two style classes in head `fpCtYO` [for the small play buttons next to playlist thumbnails] and `gHYQaG` [for the large play button in a playlist or artist page] to `--spice-text` which would make sure that the color integrates with the theme. The style is added to `head` to make the CSS changes permanent for a session.

Please tell me if I'm doing something wrong or if something could be made better. 