### PR TITLE
fix(Sleek): liked songs text + playing icon active state

### DIFF
--- a/Sleek/user.css
+++ b/Sleek/user.css
@@ -122,7 +122,9 @@ NAVBAR
 
 .main-navBar-navBarLinkActive,
 .main-navBar-navBarLinkActive:focus,
-.main-navBar-navBarLinkActive:hover {
+.main-navBar-navBarLinkActive:hover,
+.main-collectionLinkButton-selected,
+.main-collectionLinkButton-selected svg {
   color: var(--spice-nav-active-text) !important;
 }
 


### PR DESCRIPTION
fixes an issue (possibly caused by #883) where liked songs text active color didn't match right, causing it to look like this:
![Screenshot_53](https://user-images.githubusercontent.com/51394649/214990129-5aebf714-bc58-416f-80bd-63179f6a73ef.png)
this pr fixes the issue
![Screenshot_52](https://user-images.githubusercontent.com/51394649/214990205-1882641a-9a93-4aed-b1e1-a719d8dc41e9.png)
