### PR TITLE
fix(ziro): volume bar alignment with spotify connect

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -79,7 +79,7 @@
   left: 0;
   bottom: 84px;
 }
-.main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar {
+.main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar > .playback-progressbar) {
   bottom: 108px;
 }
 .playback-bar {


### PR DESCRIPTION
Hi!
This PR fixes a bug which causes the volume bar to be misaligned when spotify connect is active. 

closes #749 