### PR TITLE
fix(ziro): always display playing icon

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -533,6 +533,10 @@ label.Type__TypeElement-goli3j-0.gCwing.main-playlistEditDetailsModal-textElemen
 }
 /*playing status icon - Playlist*/
 .CCeu9OfWSwIAJqA49n84.ZcKzjCkYGeMizcSAP8UX {
+  color: var(--spice-subtext);
+  top: 10px;
+}
+.main-rootlist-rootlistItemLinkActive + .main-rootlist-statusIcons .CCeu9OfWSwIAJqA49n84.ZcKzjCkYGeMizcSAP8UX {
   color: var(--spice-main);
   top: 10px;
 }


### PR DESCRIPTION
Currently the "playing" icon is invisible when you don't have the playing playlist select. This PR changes that icon to the same color of the icon which indicates that a playlist is downloaded. 

Before:
![image](https://user-images.githubusercontent.com/26183582/224508256-796ba7a0-acd0-4a29-99a2-635ae249ce01.png)
![image](https://user-images.githubusercontent.com/26183582/224508251-6e9398a5-2df9-48d7-b8d3-b95ebf297b38.png)



After:
![image](https://user-images.githubusercontent.com/26183582/224510099-0911f2ed-ea8d-4379-8f8a-7b4771aede46.png)
![image](https://user-images.githubusercontent.com/26183582/224508228-2ae946b3-4240-401f-a90f-bfc69be47da2.png)

