### PR TITLE
fix(ziro): center playlist downloaded icon

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -536,6 +536,11 @@ label.Type__TypeElement-goli3j-0.gCwing.main-playlistEditDetailsModal-textElemen
   color: var(--spice-main);
   top: 10px;
 }
+/* download icon - Playlist */
+.hcxPtZcvjM07S6ydT685 {
+  top: 10px;
+  position: relative;
+}
 /*playing status icon - Liked Songs*/
 .CCeu9OfWSwIAJqA49n84.Frn4juLXf6zInWBEFFzr {
   color: var(--spice-main);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/26183582/224541178-261c3569-ac6a-44d1-bdb9-df32e481cdbf.png)

After:
![image](https://user-images.githubusercontent.com/26183582/224541155-3df29117-9528-46f0-b45e-6b629c10bf12.png)
