### PR TITLE
fix(ziro): hover color of selected playlist

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -73,6 +73,11 @@
 .main-rootlist-rootlist .os-scrollbar {
   padding: 0 0 0 8px;
 }
+.main-rootlist-rootlistItemLinkActive .main-rootlist-expandArrow:focus,
+.main-rootlist-rootlistItemLinkActive .main-rootlist-textWrapper:focus,
+.main-rootlist-rootlistItemLinkActive .main-rootlist-textWrapper:hover {
+  color: var(--spice-main);
+}
 /* player */
 .main-nowPlayingBar-center .playback-progressbar {
   position: absolute;


### PR DESCRIPTION
Avoids changing the text color of the selected playlist while hovering over it. 

Before:
![image](https://user-images.githubusercontent.com/26183582/224542690-5ba30ef2-17d9-420d-a0b9-8fcf9bc2f29a.png)

After:
![image](https://user-images.githubusercontent.com/26183582/224542717-acc5c8c7-b135-41ce-9521-1ac271c3afa2.png)
