### PR TITLE
fix(Dribbblish): fixes multiple visual bugs

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -894,9 +894,7 @@ section.contentSpacing {
 
 /* buddy feed w/ hidden text*/
 .buddyFeed-hide-text .NdQkQZhcYIEcJnRdAYcQ,
-.buddyFeed-hide-text .main-buddyFeed-header {
-    display: none;
-}
+.buddyFeed-hide-text .main-buddyFeed-header
 
 .buddyFeed-hide-text .main-buddyFeed-friendActivity {
     padding: 0 0 0 4px;
@@ -1025,9 +1023,4 @@ a.main-collectionLinkButton-collectionLinkButton.main-collectionLinkButton-selec
 /* playbutton color */
 .main-playButton-PlayButton > button > span {
     color: var(--spice-text);
-}
-
-/* lyrics background  */
-.lyrics-lyrics-background {
-    background-color: var(--spice-main);
 }


### PR DESCRIPTION
Bugs:
1. When you navigate to the lyrics page, the whole Spotify window shifts left by 72px, and persists even if you click out of it and go to a different page.
2. The background for the lyrics page is always black and makes the upcoming lyrics impossible to see. 

See image below:
![bug](https://user-images.githubusercontent.com/67120455/231038832-738f1313-9223-42a3-b411-19a17d41d4e1.png)


Fixes:
The changes in this branch fixes these visual bugs. 

See image below:
![fixed](https://user-images.githubusercontent.com/67120455/231038713-6bc53d8e-5143-45f8-986e-2f7593b862eb.png)
