### PR TITLE
fix(ziro): volume bar alignment with spotify connect (again)

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -84,7 +84,7 @@
   left: 0;
   bottom: 84px;
 }
-.main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar > .playback-progressbar) {
+.main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar__slider-container > .playback-progressbar) {
   bottom: 108px;
 }
 .playback-bar {

--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -84,6 +84,9 @@
   left: 0;
   bottom: 84px;
 }
+/* for older versions */
+.main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar > .playback-progressbar),
+/* for new version */
 .main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar__slider-container > .playback-progressbar) {
   bottom: 108px;
 }


### PR DESCRIPTION
Seems like the latest version changed some classes and the volume bar broke again. 