### PR TITLE
fix(Turntable): Disc not turning and not showing next and previous songs

### DIFF
--- a/Turntable/theme.js
+++ b/Turntable/theme.js
@@ -1,6 +1,15 @@
 window.addEventListener("load", rotateTurntable = () => {
   const SpicetifyOrigin = Spicetify.Player.origin;
-  const fadBtn = document.querySelector(".main-topBar-button[title='Full App Display']");
+  fadBtn = document.querySelector(".main-topBar-button[title='Full App Display']");
+  if (!fadBtn){
+    const possibleFadBtn = document.querySelectorAll(".main-topBar-button")
+    for (const btn of possibleFadBtn) {
+      if (btn._tippy !== undefined && btn._tippy.props.content === "Full App Display") {
+        fadBtn = btn;
+        break;
+      }
+    }
+  }
 
   if (!SpicetifyOrigin?._state || !fadBtn) {
     setTimeout(rotateTurntable, 250);
@@ -289,8 +298,12 @@ window.addEventListener("load", rotateTurntable = () => {
   previousSong.addEventListener("dblclick", handleFadBtn);
   nextSong.addEventListener("dblclick", handleFadBtn);
 
-  fadBtn.addEventListener("click", () => {
+  function fadBtnClick(){
     const fullAppDisplay = document.querySelector("#full-app-display");
+    if (!fullAppDisplay){
+      setTimeout(fadBtnClick, 100);
+      return;
+    }
 
     fullAppDisplay.appendChild(songPreviewContainer);
 
@@ -311,5 +324,8 @@ window.addEventListener("load", rotateTurntable = () => {
     handleFadHeart();
     handleTracksNamePreview();
     handleRotate();
-  });
+  }
+
+  fadBtn.addEventListener("click", () => fadBtnClick());
+
 });


### PR DESCRIPTION
Disc not turning, nor next and previous songs showing at bottom:
![Screenshot_20230502_164708](https://user-images.githubusercontent.com/26069774/235701813-8aa0c19d-f989-45c9-ae44-a0fc06b89f64.png)


After fix it is working as inteded: ![Screenshot_20230502_164558](https://user-images.githubusercontent.com/26069774/235701533-d5e9b69a-c009-41ca-9f01-a762033ccb10.png)

One fix was concerning Spicetify buttons, which don't necessarily have a title when creating them with `Spicetify.Topbar.Button`, but rather can use Tippy. Thus, fadBtn must also be looked for by the contents of Tippy.

Another fix made sure that the action performed when clicking fadBtn had effect after the "Full App Display" was loaded.