### PR TITLE
fix(Ziro): volume slider misalign on spotify connect

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -84,9 +84,6 @@
   left: 0;
   bottom: 84px;
 }
-/* for older versions */
-.main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar > .playback-progressbar),
-/* for new version */
 .main-nowPlayingBar-nowPlayingBar:not(:only-child) .playback-progressbar:not(.volume-bar__slider-container > .playback-progressbar) {
   bottom: 108px;
 }


### PR DESCRIPTION
Fix for issue #933 .

Before:
![connectBefore](https://github.com/spicetify/spicetify-themes/assets/58548850/94ade34d-84c4-4756-8700-4d4d8fd6df93)

After:
![afterConnect](https://github.com/spicetify/spicetify-themes/assets/58548850/d12bc866-732c-4920-a4cc-65021c74d335)
