### PR TITLE
fix(Blossom): make time visible

### DIFF
--- a/Blossom/user.css
+++ b/Blossom/user.css
@@ -137,16 +137,18 @@
 }
 
 .playback-bar {
-    width: 102vw;
-    left: -25px;
-    bottom: 67px;
-    position: relative;
-    cursor: pointer;
-}
-.main-playbackBarRemainingTime-container {
+    width: calc(100% + 82px);
+    left: -41px;
+    bottom: 74px;
     position: absolute;
-    visibility: hidden;
+    cursor: pointer;
+    transition: all 0.5s;
 }
+.playback-bar:hover {
+    width: 100%;
+    left: 0;
+}
+
 .progress-bar {
 	--fg-color: var(--spice-button-active);
 }
@@ -161,7 +163,7 @@
 }
 
 .player-controls__buttons {
-    transform: translateY(15px);
+    margin-bottom: 0;
 }
 
 .main-playPauseButton-button {


### PR DESCRIPTION
resolves #928 

preview of transition on hover
![explorer_sZPnoZg1an](https://github.com/spicetify/spicetify-themes/assets/111078063/cde56b32-22b4-4a66-9311-13f5c4117da8)
