### PR TITLE
fix(text): rounded borders on gradient

### DIFF
--- a/text/user.css
+++ b/text/user.css
@@ -329,6 +329,15 @@
     color: var(--spice-border-active);
 }
 
+.main-nowPlayingView-content.main-nowPlayingView-gradient{
+    border-radius: var(--border-radius) !important;
+}
+
+/* In case the user is also using the beautiful lyrics extension */
+.lyrics-background.os-padding:has(.main-nowPlayingView-content) .lyrics-background-container{
+    border-radius: var(--border-radius) !important;
+}
+
 /* scrollbars */
 .os-theme-spotify
     > .os-scrollbar-vertical


### PR DESCRIPTION
#### Fixes the rounded borders on the gradient in the now playing sidebar since they seemed a bit off theme.

![image](https://github.com/spicetify/spicetify-themes/assets/76207818/88564a3f-6baa-4e51-a59f-a607d508566e)
 
![image](https://github.com/spicetify/spicetify-themes/assets/76207818/2235d257-e997-42f6-9947-1cb71e9d9e3f)

> ps great work on the theme @/darkthemer, It's amazing ^_^