### PR TITLE
fix(sleek): Fixed wealthy colour scheme for the Sleek theme

### DIFF
--- a/Sleek/color.ini
+++ b/Sleek/color.ini
@@ -2,7 +2,7 @@
 ; Green on dark grey background
 text               = 8bc34a
 subtext            = b4b4b4
-nav-active-text    = 202020
+nav-active-text    = 8bc34a
 main               = 202020
 sidebar            = 202020
 player             = 242424


### PR DESCRIPTION
Updated color.ini to change nav-active-text colour to the highlight colour for the wealthy colour scheme

Before:
![image](https://github.com/spicetify/spicetify-themes/assets/10896262/027419a8-8efe-48bf-a828-c511fac7ca73)

After:
![image](https://github.com/spicetify/spicetify-themes/assets/10896262/44bebbbf-8645-4954-9299-30cf7d436cf8)

P.S. had to redo the commits and PR's as I didn't follow the guidelines; I think I have now. New to this, sorry.