### PR TITLE
fix(Sleek): improve toggle bar

### DIFF
--- a/Sleek/user.css
+++ b/Sleek/user.css
@@ -675,3 +675,40 @@ NEW HOME LAYOUT
 .nav-alt .x-searchInput-searchInputInput:focus {
   box-shadow: none;
 }
+/* 
+-------
+TOGGLE 
+-------
+*/
+.x-toggle-indicatorWrapper {
+  background-color: transparent;
+  height: 20px;
+  width: 40px;
+  box-shadow: 0 0 0 1px var(--spice-subtext);
+}
+
+input:hover:not([disabled], :active) ~ .x-toggle-indicatorWrapper {
+  background-color: var(--spice-main-secondary);
+}
+
+input:checked ~ .x-toggle-indicatorWrapper {
+  background-color: var(--spice-button);
+  box-shadow: none;
+}
+
+.x-toggle-indicator {
+  background-color: var(--spice-subtext);
+  height: 12px;
+  width: 12px;
+  top: 4px;
+  left: 3px;
+}
+
+input:not([disabled]) ~ .x-toggle-indicatorWrapper:hover .x-toggle-indicator {
+  transform: scale(1.2);
+}
+
+input:checked ~ .x-toggle-indicatorWrapper .x-toggle-indicator {
+  background-color: var(--spice-main);
+  right: 4px;
+}


### PR DESCRIPTION
In most color schemes, the toggle bars were filled with the same colour and there was no distinction between the indicator and the wrapper background. This commit fixes that.

Before:

![Screenshot 2023-12-16 014208](https://github.com/spicetify/spicetify-themes/assets/87632612/e419f778-c0ff-44c5-bab4-4eeb8c75c701)

After:

![Screenshot 2023-12-16 014301](https://github.com/spicetify/spicetify-themes/assets/87632612/0d399d31-a2a5-483d-a809-a40e5a65f1cc)
