### PR TITLE
chore(Dribbblish): update change color schemes section with gruvbox

### DIFF
--- a/Dribbblish/README.md
+++ b/Dribbblish/README.md
@@ -89,7 +89,7 @@ xpui.js_repl_8008 = ,${1}56,
 ```
 
 ## Change Color Schemes
-There are 9 color schemes you can choose: `base`, `white`, `dark`, `dracula`, `nord-dark`, `nord-light`, `beach-sunset`, `samourai`, `purple`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, and `catppuccin-mocha`. Change scheme with commands:
+There are 9 color schemes you can choose: `base`, `white`, `dark`, `dracula`, `nord-dark`, `nord-light`, `beach-sunset`, `samourai`, `purple`, `gruvbox`, `gruvbox-material-dark`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, and `catppuccin-mocha`. Change scheme with commands:
 ```
 spicetify config color_scheme <scheme name>
 spicetify apply

--- a/Dribbblish/README.md
+++ b/Dribbblish/README.md
@@ -89,7 +89,7 @@ xpui.js_repl_8008 = ,${1}56,
 ```
 
 ## Change Color Schemes
-There are 9 color schemes you can choose: `base`, `white`, `dark`, `dracula`, `nord-dark`, `nord-light`, `beach-sunset`, `samourai`, `purple`, `gruvbox`, `gruvbox-material-dark`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, and `catppuccin-mocha`. Change scheme with commands:
+There are 9 color schemes you can choose: `base`, `white`, `dark`, `dracula`, `nord-dark`, `nord-light`, `beach-sunset`, `samurai`, `purple`, `gruvbox`, `gruvbox-material-dark`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, and `catppuccin-mocha`. Change scheme with commands:
 ```
 spicetify config color_scheme <scheme name>
 spicetify apply


### PR DESCRIPTION
updates change color schemes section to add the two gruvbox themes that for some reason wasn't there