### PR TITLE
fix(StarryNight): fix zero playbar width on startup and add instruction to resize width

### DIFF
--- a/StarryNight/README.md
+++ b/StarryNight/README.md
@@ -6,6 +6,8 @@
 
 ## More
 
+> Playbar panel is resizable using the resize bar from Now Playing View and Queue card.
+
 ### Created by
 
 - https://github.com/b-chen00

--- a/StarryNight/theme.js
+++ b/StarryNight/theme.js
@@ -55,7 +55,7 @@ waitForElement([".Root__top-container"], ([topContainer]) => {
       if (entry.target === rightbar) {
         let newWidth = entry.contentRect.width;
         if (newWidth == 0) {
-          const localStorageWidth = localStorage.getItem('223ni6f2epqcidhx5etjafeai:panel-width-saved') + 'px';
+          const localStorageWidth = localStorage.getItem('223ni6f2epqcidhx5etjafeai:panel-width-saved');
           if (localStorageWidth) {
             newWidth = localStorageWidth;
           }


### PR DESCRIPTION
Messed up applying width from localstorage which makes playbar disappear on startup if the Now Playing View or Queue card isn't already active.