### PR TITLE
docs(text): fix and add info regarding transparent window controls

### DIFF
--- a/text/README.md
+++ b/text/README.md
@@ -170,7 +170,7 @@ body::after {
        this size is set for 100% zoom
     */
     width: 135px;
-    height: 40px;
+    height: 64px;
 }
 ```
 

--- a/text/README.md
+++ b/text/README.md
@@ -170,6 +170,9 @@ body::after {
        this size is set for 100% zoom
     */
     width: 135px;
+   /* depending on what global status bar 
+      style is enabled height need to be 
+      changed accordingly. */
     height: 64px;
 }
 ```


### PR DESCRIPTION
40px does not cover the entire button with the new spotify design.

The buttons now cover 64px in height.

The issue can be seen in SC of https://github.com/spicetify/spicetify-themes/issues/1047 and https://github.com/spicetify/spicetify-themes/issues/1057 even if the issues are not regarding that issue.