### PR TITLE
Dribbblish: Gruvbox sidebar color fix

### DIFF
--- a/Dribbblish/color.ini
+++ b/Dribbblish/color.ini
@@ -164,7 +164,7 @@ misc               = BFBFBF
 [gruvbox]
 text               = fbf1c7
 subtext            = d5c4a1
-sidebar-text       = 32302f
+sidebar-text       = ebe1b7
 main               = 292828
 sidebar            = 689d6a
 player             = 292828


### PR DESCRIPTION
Fixes: #1067

Preview:

![image](https://github.com/spicetify/spicetify-themes/assets/31374920/e61327e7-7505-4f83-8afc-023aaa6e64d4)
