### PR TITLE
fix(StarryNight):  fix main container in global nav

### DIFF
--- a/StarryNight/user.css
+++ b/StarryNight/user.css
@@ -22,6 +22,13 @@
     "left-sidebar    main-view         right-sidebar";
 }
 
+.global-nav .Root__top-container {
+  grid-template-areas:
+    "global-nav global-nav global-nav"
+    "left-sidebar main-view now-playing-bar"
+    "left-sidebar main-view right-sidebar";
+}
+
 .Root__right-sidebar {
   height: calc(100vh - 450px);
   width: min-content;
@@ -198,6 +205,7 @@
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }


### PR DESCRIPTION
fixes Root_container styles in global nav

issue caused by global nav
![image](https://github.com/spicetify/spicetify-themes/assets/93819264/3a208a91-e54d-4d15-b320-30c319e26acd)

expected behavior:
![image](https://github.com/spicetify/spicetify-themes/assets/93819264/8605ca9d-2216-4f19-8878-bbe946c99f86)
