### PR TITLE
fix(text): fix overflow in Liked Songs genre carousel

### DIFF
--- a/text/user.css
+++ b/text/user.css
@@ -108,7 +108,6 @@
 .Root__top-bar {
     border: var(--border-width) solid transparent;
 }
-.Root__main-view,
 .Root__nav-bar,
 .Root__now-playing-bar {
     overflow: visible;
@@ -309,6 +308,7 @@
 }
 .Root__main-view::before {
     content: "Main";
+    position: fixed;
 }
 .Root__now-playing-bar::before {
     content: "Playing";


### PR DESCRIPTION
See issue: #1092 

Screenshot of carousel:

<img width="1041" alt="Screenshot 2024-07-09 at 10 44 00 PM" src="https://github.com/spicetify/spicetify-themes/assets/17755970/3124a6bf-53ed-4ea7-9d32-560d4b3a287e">
