### PR TITLE
Fix Dribbblish narbar offset

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -71,6 +71,7 @@ body {
 .Root__globalNav {
     background-color: var(--spice-main) !important;
     border-radius: var(--corner-radius) var(--corner-radius) 0 0 !important;
+    margin: 0;
     margin-left: calc(var(--left-sidebar-width) * 1px);
 }
 


### PR DESCRIPTION
Navbar after maybe the new update sticks to the topbar and looks ugly.

![image](https://github.com/user-attachments/assets/7b9a0cfb-e7a6-49f8-861f-221035956060)

This is becase it's being injected negative value from:
```css
.Root__globalNav {
    ...
    margin: calc(var(--panel-gap)*-1);
    padding: calc(var(--panel-gap));
    position: relative;
}
```

This PR resets the margin to default value and makes the navbar look more seemless.