### PR TITLE
fix(Dribbblish): search history list being hidden

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -73,6 +73,7 @@ body {
     border-radius: var(--corner-radius) var(--corner-radius) 0 0 !important;
     margin: 0;
     margin-left: calc(var(--left-sidebar-width) * 1px);
+    z-index: 10;
 }
 
 .Root__globalNav .main-globalNav-historyButtonsContainer,


### PR DESCRIPTION
Recently, Spotify introduced an update that integrates the search history list into the search bar.
i have resolved the issue where the search history list was being hidden due to this update.

![Desktop Screenshot 2025 01 17 - 21 11 10 36](https://github.com/user-attachments/assets/a6f49bab-d902-4bbd-80b5-7914b617b519)
