### PR TITLE
docs(text): fix instructions for removing whitespace when viewing lists of songs

### DIFF
--- a/text/README.md
+++ b/text/README.md
@@ -96,7 +96,7 @@ created by [darkthemer](https://github.com/darkthemer/)
 
 ```ini
 [Patch]
-xpui.js_find_8008 = ,(\w+=)56,
+xpui.js_find_8008 = ,(rowHeight:\s*)[a-zA-Z0-9_]+,
 xpui.js_repl_8008 = ,${1}32,
 ```
 

--- a/text/README.md
+++ b/text/README.md
@@ -92,7 +92,7 @@ created by [darkthemer](https://github.com/darkthemer/)
 
 ### Notes
 
--   **IMPORTANT:** Add the following to your `config-xpui.ini` file. Details as to why are explained [here](https://github.com/JulienMaille/spicetify-dynamic-theme#important). Run `spicetify apply` after adding these lines.
+-   **IMPORTANT:** Add the following to your `config-xpui.ini` file. This is to ensure the height of the song rows in playlists/albums matches what the theme expects them to be. Run `spicetify apply` after adding these lines. Also, make sure to remove them when you stop using this theme.
 
 ```ini
 [Patch]


### PR DESCRIPTION
Spotify has changed their xpui.js. I updated the instructions to match rowHeight (the height of the song row) and set it to 32.

This could probably be done better by matching the value 32 (like the old way), but from my quick look it now seems to come from somewhere outside of the xpui.js file. I'm not super familiar with spicetify's find/replace system, so this seemed like the easiest fix.

p.s. I wasn't sure to tag this docs or fix. I can change it if need be.