### PR TITLE
fix progress bar transition

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -501,9 +501,9 @@ li>div::after {
     transition: left 1s linear;
 }
 
-.playback-progressbar-isInteractive .DuvrswZugGajIFNXObAr .x-progressBar-fillColor,
-.playback-progressbar-isInteractive .DuvrswZugGajIFNXObAr .progress-bar__slider {
-    transition: none;
+/* progress bar moves instant if clicked */
+*:has(.x-progressBar-fillColor, .progress-bar__slider):active :is(.x-progressBar-fillColor, .progress-bar__slider) {
+    transition-duration: 0.001s;
 }
 
 /* right sidebar text */


### PR DESCRIPTION
fixed the progress bar transition so the progress bar moves instantly when clicked instead of crawling there for 1s.
(normal playback transition is unaffected)