### PR TITLE
fix(StarryNight) Top Banner Margin

### DIFF
--- a/StarryNight/user.css
+++ b/StarryNight/user.css
@@ -22,6 +22,7 @@
 
 .global-nav .Root__top-container {
   grid-template-areas:
+    "top-banner top-banner top-banner"
     "global-nav global-nav global-nav"
     "left-sidebar main-view now-playing-bar"
     "left-sidebar main-view right-sidebar" !important;


### PR DESCRIPTION
Call to the `grid-template-areas` property on `.global-nav` and `.Root__top-container` was missing a reference to top-banner, causing layout issues in Starry Night. This may or may not be the final location of this bug..