### PR TITLE
fix(text): corrected border-radius on active tab in category selector

### DIFF
--- a/text/user.css
+++ b/text/user.css
@@ -660,7 +660,8 @@ form .main-topBar-searchBar:placeholder-shown {
 .search-searchCategory-catergoryGrid *,
 .main-shelf-subHeader *,
 .ChipInnerComponent-sm,
-.ChipInnerComponent-sm-selected {
+.ChipInnerComponent-sm-selected,
+.ChipInnerComponent-sm-selected-isUsingKeyboard {
     border-radius: var(--border-radius);
 }
 .main-actionBar-ActionBar


### PR DESCRIPTION
when the keyboard had focus on the category selector the border-radius wouldn't apply this fixes this 

before:
![before](https://github.com/user-attachments/assets/9cdfb495-4a48-4978-b758-2f8c9e03f78f)
after:
![after](https://github.com/user-attachments/assets/35bfe5e9-0609-4e72-b931-26164dce0a7a)

