### PR TITLE
feat(Dribbblish): add `kanagawa` color scheme

### DIFF
--- a/Dribbblish/color.ini
+++ b/Dribbblish/color.ini
@@ -308,7 +308,7 @@ notification-error = f38ba8 ; Red
 misc               = 45475a ; Surface1
 
 [tokyo-night]
-text               = 7aa2f7 ; Text 
+text               = 7aa2f7 ; Text
 subtext            = bb9af7 ; Subtext1
 sidebar-text       = c0caf5 ; Text
 main               = 1a1b26 ; Base
@@ -324,3 +324,21 @@ tab-active         = 14141b ; Surface0
 notification       = 1a1b26 ; Surface0
 notification-error = f7768e ; Red
 misc               = ff9e64 ; Surface1
+
+[kanagawa]
+text               = dcd7ba ; Text
+subtext            = c8c093 ; Subtext1
+sidebar-text       = dcd7ba ; Text
+main               = 1f1f28 ; Base
+sidebar            = 16161d ; Mantle
+player             = 1f1f28 ; Base
+card               = 1f1f28 ; Base
+shadow             = 16161d ; Mantle
+selected-row       = 9cabca ; Overlay2
+button             = 7e9cd8 ; Overlay1
+button-active      = 9cabca ; Overlay2
+button-disabled    = 54546d ; Overlay0
+tab-active         = 363646 ; Surface0
+notification       = 363646 ; Surface0
+notification-error = e46876 ; Red
+misc               = 54546d ; Surface1


### PR DESCRIPTION
based of https://github.com/rebelot/kanagawa.nvim