### PR TITLE
feat(text): add everforest dark color scheme

### DIFF
--- a/text/color.ini
+++ b/text/color.ini
@@ -267,4 +267,19 @@ main               = 3e3e29
 notification       = 8c8e59
 notification-error = 787a4d
 subtext            = 838383
-text               = a3a3a3
+
+[EverforestDark]
+;https://github.com/sainnhe/everforest
+accent             = a7c080
+accent-active      = a7c080
+accent-inactive    = 2d353b
+banner             = a7c080
+border-active      = a7c080
+border-inactive    = 343f44
+header             = 425047
+highlight          = 425047
+main               = 2d353b
+notification       = 83c092
+notification-error = e67e80
+subtext            = 7a8478
+text               = 859289text               = a3a3a3


### PR DESCRIPTION
Added `Everforest Dark` color scheme from https://github.com/sainnhe/everforest, matching the semantics and palette of the `Medium` variant.