### PR TITLE
feat(text): better catppuccin color

### DIFF
--- a/text/color.ini
+++ b/text/color.ini
@@ -32,16 +32,16 @@ text               = FFFFFF
 
 [CatppuccinMocha]
 ;https://github.com/catppuccin/catppuccin
-accent             = a6e3a1
-accent-active      = a6e3a1
+accent             = cba6f7
+accent-active      = cba6f7
 accent-inactive    = 1e1e2e
-banner             = a6e3a1
-border-active      = a6e3a1
+banner             = cba6f7
+border-active      = cba6f7
 border-inactive    = 313244
 header             = 585b70
 highlight          = 585b70
 main               = 1e1e2e
-notification       = 89b4fa
+notification       = 313244
 notification-error = f38ba8
 subtext            = a6adc8
 text               = cdd6f4


### PR DESCRIPTION
this pr use catppuccin mauve as hightlight color, this is default for most catppuccin mocha style and more comfy to look at